### PR TITLE
Add presentation tier HTML samples

### DIFF
--- a/ux-specs/chat-input.html
+++ b/ux-specs/chat-input.html
@@ -1,0 +1,18 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <title>ChatInput Sample</title>
+  <link rel="stylesheet" href="ui-sample.css" />
+</head>
+<body>
+  <div class="container">
+    <h1>ChatInput</h1>
+    <div class="input-area">
+      <textarea rows="3" placeholder="Type your message..."></textarea>
+      <button>Send</button>
+    </div>
+    <p class="footer">The assistant may produce incorrect information.</p>
+  </div>
+</body>
+</html>

--- a/ux-specs/chat-messages.html
+++ b/ux-specs/chat-messages.html
@@ -1,0 +1,18 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <title>ChatMessages Sample</title>
+  <link rel="stylesheet" href="ui-sample.css" />
+</head>
+<body>
+  <div class="container">
+    <h1>ChatMessages</h1>
+    <div class="messages">
+      <div class="message user">How do I set up the project?</div>
+      <div class="message assistant">You can run <code>docker compose up</code> to start all services.</div>
+      <div class="message user">Thanks!</div>
+    </div>
+  </div>
+</body>
+</html>

--- a/ux-specs/config-modal.html
+++ b/ux-specs/config-modal.html
@@ -1,0 +1,19 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <title>ConfigModal Sample</title>
+  <link rel="stylesheet" href="ui-sample.css" />
+</head>
+<body>
+  <div class="modal">
+    <div class="modal-content">
+      <h2>API Keys</h2>
+      <input type="text" placeholder="Gemini API Key" class="repo-input" />
+      <input type="text" placeholder="OpenAI API Key (optional)" class="repo-input" />
+      <input type="text" placeholder="Anthropic API Key (optional)" class="repo-input" />
+      <button class="action-button">Save</button>
+    </div>
+  </div>
+</body>
+</html>

--- a/ux-specs/left-sidebar.html
+++ b/ux-specs/left-sidebar.html
@@ -1,0 +1,24 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <title>LeftSidebar Sample</title>
+  <link rel="stylesheet" href="ui-sample.css" />
+</head>
+<body>
+  <div class="sidebar">
+    <h2>Conversations</h2>
+    <ul class="repo-list">
+      <li>Chat 1</li>
+      <li>Chat 2</li>
+    </ul>
+    <hr />
+    <h2>Repositories</h2>
+    <ul class="repo-list">
+      <li>Repo A</li>
+      <li>Repo B</li>
+    </ul>
+    <button class="action-button">Configure API Keys</button>
+  </div>
+</body>
+</html>

--- a/ux-specs/repository-manager.html
+++ b/ux-specs/repository-manager.html
@@ -1,0 +1,19 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <title>RepositoryManager Sample</title>
+  <link rel="stylesheet" href="ui-sample.css" />
+</head>
+<body>
+  <div class="container">
+    <h1>RepositoryManager</h1>
+    <input type="text" class="repo-input" placeholder="Repository URL" />
+    <button class="action-button">Add Repository</button>
+    <ul class="repo-list">
+      <li>Repo A <button class="action-button">Remove</button></li>
+      <li>Repo B <button class="action-button">Remove</button></li>
+    </ul>
+  </div>
+</body>
+</html>

--- a/ux-specs/right-sidebar.html
+++ b/ux-specs/right-sidebar.html
@@ -1,0 +1,18 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <title>RightSidebar Sample</title>
+  <link rel="stylesheet" href="ui-sample.css" />
+</head>
+<body>
+  <div class="right-sidebar">
+    <h2>Repository Info</h2>
+    <p>Name: Repo A</p>
+    <p>Cache ID: abc123</p>
+    <div class="placeholder">
+      <p>Context panel...</p>
+    </div>
+  </div>
+</body>
+</html>

--- a/ux-specs/ui-sample.css
+++ b/ux-specs/ui-sample.css
@@ -1,0 +1,110 @@
+body {
+  background-color: #343541;
+  color: #ffffff;
+  font-family: Arial, sans-serif;
+  margin: 0;
+  padding: 0;
+}
+.container {
+  padding: 20px;
+}
+.messages {
+  background: #444654;
+  border-radius: 8px;
+  padding: 10px;
+  margin-bottom: 20px;
+}
+.message {
+  padding: 8px 12px;
+  margin-bottom: 8px;
+  border-radius: 6px;
+}
+.message.user {
+  background: #2a2b32;
+  text-align: right;
+}
+.message.assistant {
+  background: #3a3b43;
+}
+.input-area {
+  display: flex;
+}
+.input-area textarea {
+  flex: 1;
+  padding: 10px;
+  background: #202123;
+  color: #ffffff;
+  border: 1px solid #555;
+  border-radius: 4px;
+}
+.input-area button {
+  padding: 10px;
+  background: #444654;
+  color: #ffffff;
+  border: none;
+  margin-left: 5px;
+  border-radius: 4px;
+  cursor: pointer;
+}
+.sidebar {
+  width: 260px;
+  background: #202123;
+  color: #ffffff;
+  padding: 20px;
+}
+.repo-list {
+  list-style: none;
+  padding: 0;
+  margin: 0;
+}
+.repo-list li {
+  padding: 6px 0;
+  border-bottom: 1px solid #444;
+  display: flex;
+  justify-content: space-between;
+}
+.action-button {
+  padding: 6px 10px;
+  background: #444654;
+  color: #ffffff;
+  border: none;
+  border-radius: 4px;
+  cursor: pointer;
+  margin-top: 5px;
+}
+.repo-input {
+  width: 100%;
+  padding: 6px 10px;
+  margin-bottom: 10px;
+  background: #202123;
+  color: #ffffff;
+  border: 1px solid #555;
+  border-radius: 4px;
+}
+.modal {
+  position: fixed;
+  top: 0;
+  left: 0;
+  right: 0;
+  bottom: 0;
+  background: rgba(0, 0, 0, 0.6);
+  display: flex;
+  justify-content: center;
+  align-items: center;
+}
+.modal-content {
+  background: #202123;
+  padding: 20px;
+  border-radius: 8px;
+  width: 300px;
+}
+.right-sidebar {
+  width: 260px;
+  background: #202123;
+  padding: 20px;
+  position: absolute;
+  right: 0;
+  top: 0;
+  height: 100vh;
+  color: #ffffff;
+}


### PR DESCRIPTION
## Summary
- add minimal CSS for UI samples
- provide sample HTML pages for ChatMessages, ChatInput, RepositoryManager, LeftSidebar, RightSidebar and ConfigModal

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68543e085f74832a925e625d78424de2